### PR TITLE
F: Add error descriptions in tooltips

### DIFF
--- a/rsconcept/frontend/src/domain/rslang/error.ts
+++ b/rsconcept/frontend/src/domain/rslang/error.ts
@@ -119,13 +119,3 @@ export function getRSErrorPrefix(code: RSErrorCode): string {
 export function isCritical(code: RSErrorCode): boolean {
   return code !== RSErrorCode.localDoubleDeclare && code !== RSErrorCode.localNotUsed;
 }
-
-/** Returns a normalized editor range for an error. */
-export function getRSErrorRange(error: RSErrorDescription): { from: number; to: number } {
-  const from = Math.max(error.from, 0);
-  const to = typeof error.to === 'number' ? Math.max(error.to, from) : from;
-  return {
-    from,
-    to: to > from ? to : from + 1
-  };
-}

--- a/rsconcept/frontend/src/domain/rslang/index.ts
+++ b/rsconcept/frontend/src/domain/rslang/index.ts
@@ -1,5 +1,5 @@
 export { readErrorAnnotation, readTypeAnnotation } from './ast-annotations';
-export { getRSErrorRange, RSErrorCode, type RSErrorDescription } from './error';
+export { RSErrorCode, type RSErrorDescription } from './error';
 export { type CalculatorEvaluateOptions, type CalculatorResult, RSCalculator } from './eval/calculator';
 export { makeValuePath, type Value, type ValuePath } from './eval/value';
 export { normalizeAST } from './parser/normalize';

--- a/rsconcept/frontend/src/domain/rslang/semantic/type-auditor.test.ts
+++ b/rsconcept/frontend/src/domain/rslang/semantic/type-auditor.test.ts
@@ -153,6 +153,7 @@ const correctTypesData = [
 const errorData = [
   // Identifiers
   ['X42', { code: RSErrorCode.globalNotTyped, from: 0, to: 3, params: ['X42'] }],
+  ['F42[X1]', { code: RSErrorCode.globalNotTyped, from: 0, to: 3, params: ['F42'] }],
   // Radicals
   ['R1', { code: RSErrorCode.radicalUsage, from: 0, to: 2, params: ['R1'] }],
   ['[a∈ℬ(R1)] R1\\a', { code: RSErrorCode.radicalUsage, from: 10, to: 12, params: ['R1'] }],

--- a/rsconcept/frontend/src/domain/rslang/semantic/type-auditor.ts
+++ b/rsconcept/frontend/src/domain/rslang/semantic/type-auditor.ts
@@ -349,7 +349,7 @@ export class TypeAuditor {
     const funcName = getNodeText(node.children[0]);
     const funcType = this.context.get(funcName);
     if (funcType?.typeID !== TypeID.function && funcType?.typeID !== TypeID.predicate) {
-      return this.onError(RSErrorCode.globalNotTyped, node, [funcName]);
+      return this.onError(RSErrorCode.globalNotTyped, node.children[0], [funcName]);
     }
     if (this.annotateTypes) {
       annotateType(node.children[0], funcType);

--- a/rsconcept/frontend/src/features/rsform/components/editor-rsexpression/editor-rsexpression.tsx
+++ b/rsconcept/frontend/src/features/rsform/components/editor-rsexpression/editor-rsexpression.tsx
@@ -6,7 +6,7 @@ import { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
 
 import { type Constituenta, CstStatus, type RSForm } from '@/domain/library';
 import { getAnalysisFor, inferStatus } from '@/domain/library/rsform-api';
-import { type AnalysisFull, getRSErrorRange, type RSErrorDescription, TokenID } from '@/domain/rslang';
+import { type AnalysisFull, type RSErrorDescription, TokenID } from '@/domain/rslang';
 import { rslangParser } from '@/domain/rslang';
 
 import {
@@ -150,11 +150,10 @@ export function EditorRSExpression({
     if (!rsInput.current) {
       return;
     }
-    const range = getRSErrorRange(error);
     rsInput.current?.view?.dispatch({
       selection: {
-        anchor: range.from,
-        head: range.to
+        anchor: error.from,
+        head: error.to
       }
     });
     rsInput.current?.view?.focus();

--- a/rsconcept/frontend/src/features/rsform/components/rs-input/error-ranges.ts
+++ b/rsconcept/frontend/src/features/rsform/components/rs-input/error-ranges.ts
@@ -1,7 +1,7 @@
 import { RangeSetBuilder } from '@codemirror/state';
 import { Decoration, type DecorationSet, EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
 
-import { getRSErrorRange, type RSErrorDescription } from '@/domain/rslang';
+import { type RSErrorDescription } from '@/domain/rslang';
 
 import { APP_COLORS } from '@/styling/colors';
 
@@ -40,20 +40,19 @@ class ErrorRangesPlugin {
   decorations: DecorationSet;
   errors: readonly RSErrorDescription[];
 
-  constructor(view: EditorView, errors: readonly RSErrorDescription[]) {
+  constructor(errors: readonly RSErrorDescription[]) {
     this.errors = errors;
-    this.decorations = this.buildDecorations(view);
+    this.decorations = this.buildDecorations();
   }
 
   update(update: ViewUpdate) {
     if (update.docChanged || update.viewportChanged) {
-      this.decorations = this.buildDecorations(update.view);
+      this.decorations = this.buildDecorations();
     }
   }
 
-  buildDecorations(view: EditorView): DecorationSet {
+  buildDecorations(): DecorationSet {
     const builder = new RangeSetBuilder<Decoration>();
-    const docLength = view.state.doc.length;
     const sortedErrors = [...this.errors].sort((left, right) => {
       if (left.from !== right.from) {
         return left.from - right.from;
@@ -71,26 +70,22 @@ class ErrorRangesPlugin {
     }
 
     for (const error of nonOverlappingErrors) {
-      const range = getSafeErrorRange(error, docLength);
-      if (!range) {
-        continue;
-      }
-
-      builder.add(range.from, Math.min(range.from + 1, range.to), errorStartMark);
-      builder.add(range.from, range.to, errorRangeMark);
-      builder.add(Math.max(range.to - 1, range.from), range.to, errorEndMark);
+      builder.add(error.from, Math.min(error.from + 1, error.to), errorStartMark);
+      builder.add(error.from, error.to, errorRangeMark);
+      builder.add(Math.max(error.to - 1, error.from), error.to, errorEndMark);
     }
 
     return builder.finish();
   }
 }
 
+/** Returns a list of extensions for displaying error ranges in the editor. */
 export function rsErrorRanges(errors: readonly RSErrorDescription[]) {
   return [
     ViewPlugin.fromClass(
       class extends ErrorRangesPlugin {
-        constructor(view: EditorView) {
-          super(view, errors);
+        constructor() {
+          super(errors);
         }
       },
       {
@@ -99,18 +94,4 @@ export function rsErrorRanges(errors: readonly RSErrorDescription[]) {
     ),
     errorRangesTheme
   ];
-}
-
-function getSafeErrorRange(error: RSErrorDescription, docLength: number): { from: number; to: number } | null {
-  if (docLength <= 0) {
-    return null;
-  }
-
-  const range = getRSErrorRange(error);
-  const from = Math.min(Math.max(range.from, 0), docLength - 1);
-  const to = Math.min(Math.max(range.to, from + 1), docLength);
-  if (to <= from) {
-    return null;
-  }
-  return { from, to };
 }

--- a/rsconcept/frontend/src/features/rsform/components/rs-input/rs-input.tsx
+++ b/rsconcept/frontend/src/features/rsform/components/rs-input/rs-input.tsx
@@ -69,30 +69,32 @@ interface RSInputProps extends Pick<
   | 'style'
   | 'className'
 > {
+  schema?: RSForm;
+  errors?: readonly RSErrorDescription[] | null;
+
   ref?: React.Ref<ReactCodeMirrorRef>;
   label?: string;
   disabled?: boolean;
   portalHoverTooltips?: boolean;
+
   onChange?: (newValue: string) => void;
   onAnalyze?: () => void;
-  schema?: RSForm;
   onOpenEdit?: (cstID: number) => void;
-  errors?: readonly RSErrorDescription[] | null;
 }
 
 export function RSInput({
+  schema,
+  errors,
+
   label,
   disabled,
   portalHoverTooltips,
 
-  schema,
-  onOpenEdit,
-  errors,
-
+  ref,
   className,
   style,
-  ref,
 
+  onOpenEdit,
   onAnalyze,
   ...restProps
 }: RSInputProps) {
@@ -136,7 +138,7 @@ export function RSInput({
       : []),
     ccBracketMatching(),
     ...(!schema || !onOpenEdit ? [] : [rsNavigation(schema, onOpenEdit)]),
-    ...(!schema ? [] : [rsHoverTooltip(schema, onOpenEdit !== undefined)])
+    ...(!schema ? [] : [rsHoverTooltip(schema, errors, onOpenEdit !== undefined)])
   ];
 
   function handleAutoComplete(text: RSTextWrapper): boolean {

--- a/rsconcept/frontend/src/features/rsform/components/rs-input/tooltip.ts
+++ b/rsconcept/frontend/src/features/rsform/components/rs-input/tooltip.ts
@@ -5,45 +5,61 @@ import clsx from 'clsx';
 import { type Constituenta, type RSForm } from '@/domain/library';
 import { isBasicConcept } from '@/domain/library/rsform-api';
 import { type ExpressionType, readTypeAnnotation, TokenID } from '@/domain/rslang';
-import { labelType } from '@/domain/rslang/labels';
+import { isCritical, type RSErrorDescription } from '@/domain/rslang/error';
+import { describeRSError, labelType } from '@/domain/rslang/labels';
 
 import { type AstNode } from '@/utils/parsing';
 
 import { Local } from './parse/parser.terms';
 import { findAliasAt } from './utils';
 
-const tooltipProducer = (schema: RSForm, canClick?: boolean) => {
+const tooltipProducer = (schema: RSForm, errors?: readonly RSErrorDescription[] | null, canClick?: boolean) => {
   return hoverTooltip((view, pos) => {
-    const data = findAliasAt(pos, view.state);
-    if (!data) {
-      return null;
-    }
-    if (data.node.type.id !== Local) {
-      const cst = schema.cstByAlias.get(data.alias);
+    const aliasData = findAliasAt(pos, view.state);
+    const rangedErrors = errors?.filter(error => pos >= error.from && pos < error.to) ?? null;
+    if (!aliasData) {
+      if (!rangedErrors || rangedErrors.length === 0) {
+        return null;
+      }
+      const [current] = rangedErrors;
       return {
-        pos: data.node.from,
-        end: data.node.to,
+        pos: current.from,
+        end: current.to,
         above: false,
-        create: () => domTooltipConstituenta(cst, canClick)
+        create: () => domTooltipErrors(rangedErrors)
+      };
+    }
+
+    if (aliasData.node.type.id !== Local) {
+      const cst = schema.cstByAlias.get(aliasData.alias);
+      return {
+        pos: aliasData.node.from,
+        end: aliasData.node.to,
+        above: false,
+        create: () => domTooltipConstituenta(cst ?? null, rangedErrors ?? null, canClick)
       };
     } else {
       const parse = schema.analyzer.checkFull(view.state.doc.toString(), { annotateTypes: true });
       let type: ExpressionType | null = null;
       if (parse.ast) {
-        type = findLocalType(parse.ast, data.alias, data.node.from);
+        type = findLocalType(parse.ast, aliasData.alias, aliasData.node.from);
       }
       return {
-        pos: data.node.from,
-        end: data.node.to,
+        pos: aliasData.node.from,
+        end: aliasData.node.to,
         above: false,
-        create: () => domTooltipLocal(data.alias, type)
+        create: () => domTooltipLocal(aliasData.alias, type, rangedErrors ?? null)
       };
     }
   });
 };
 
-export function rsHoverTooltip(schema: RSForm, canClick?: boolean): Extension {
-  return [tooltipProducer(schema, canClick)];
+export function rsHoverTooltip(
+  schema: RSForm,
+  errors?: readonly RSErrorDescription[] | null,
+  canClick?: boolean
+): Extension {
+  return [tooltipProducer(schema, errors, canClick)];
 }
 
 // ========= Internal =========
@@ -63,7 +79,7 @@ function findLocalType(ast: AstNode, alias: string, pos: number): ExpressionType
   return null;
 }
 
-function domTooltipLocal(aliasText: string, type: ExpressionType | null): TooltipView {
+function createTooltipContainer(): HTMLDivElement {
   const dom = document.createElement('div');
   dom.className = clsx(
     'max-h-100 max-w-100 min-w-40',
@@ -74,6 +90,31 @@ function domTooltipLocal(aliasText: string, type: ExpressionType | null): Toolti
     'text-sm font-main bg-card',
     'select-none cursor-auto'
   );
+  return dom;
+}
+
+function appendErrorRows(dom: HTMLDivElement, errors: readonly RSErrorDescription[]) {
+  for (const error of errors) {
+    const row = document.createElement('p');
+    row.className = 'text-destructive';
+    const title = isCritical(error.code) ? 'Ошибка' : 'Предупреждение';
+    row.innerText = `${title}: ${describeRSError(error.code, error.params)}`;
+    dom.appendChild(row);
+  }
+}
+
+function domTooltipErrors(errors: readonly RSErrorDescription[]): TooltipView {
+  const dom = createTooltipContainer();
+  appendErrorRows(dom, errors);
+  return { dom };
+}
+
+function domTooltipLocal(
+  aliasText: string,
+  type: ExpressionType | null,
+  errors: readonly RSErrorDescription[] | null
+): TooltipView {
+  const dom = createTooltipContainer();
 
   const alias = document.createElement('p');
   alias.className = 'font-math';
@@ -81,20 +122,22 @@ function domTooltipLocal(aliasText: string, type: ExpressionType | null): Toolti
   alias.innerHTML = `<b>${aliasText}:</b> ${labelType(type)}`;
   dom.appendChild(alias);
 
+  if (errors && errors.length > 0) {
+    const divider = document.createElement('p');
+    divider.className = 'my-1 border-t';
+    dom.appendChild(divider);
+    appendErrorRows(dom, errors);
+  }
+
   return { dom: dom };
 }
 
-function domTooltipConstituenta(cst?: Constituenta, canClick?: boolean): TooltipView {
-  const dom = document.createElement('div');
-  dom.className = clsx(
-    'max-h-100 max-w-100 min-w-40',
-    'dense',
-    'p-2',
-    'rounded-md shadow-md',
-    'cc-scroll-y',
-    'text-sm font-main bg-card',
-    'select-none cursor-auto'
-  );
+function domTooltipConstituenta(
+  cst: Constituenta | null,
+  errors: readonly RSErrorDescription[] | null,
+  canClick?: boolean
+): TooltipView {
+  const dom = createTooltipContainer();
 
   if (!cst) {
     const text = document.createElement('p');
@@ -154,5 +197,13 @@ function domTooltipConstituenta(cst?: Constituenta, canClick?: boolean): Tooltip
       dom.appendChild(clickTip);
     }
   }
+
+  if (errors && errors.length > 0) {
+    const divider = document.createElement('p');
+    divider.className = 'my-1 border-t';
+    dom.appendChild(divider);
+    appendErrorRows(dom, errors);
+  }
+
   return { dom: dom };
 }

--- a/rsconcept/frontend/src/features/rsmodel/pages/rsmodel-page/tab-evaluator/form-evaluator.tsx
+++ b/rsconcept/frontend/src/features/rsmodel/pages/rsmodel-page/tab-evaluator/form-evaluator.tsx
@@ -9,7 +9,6 @@ import { inferEvalStatus, prepareValueString } from '@/domain/library/rsmodel-ap
 import {
   type AnalysisFull,
   type CalculatorResult,
-  getRSErrorRange,
   type RSErrorDescription,
   TokenID,
   type Typification
@@ -109,11 +108,10 @@ export function FormEvaluator({ id, className }: FormEvaluatorProps) {
     if (!rsInput.current) {
       return;
     }
-    const range = getRSErrorRange(error);
     rsInput.current?.view?.dispatch({
       selection: {
-        anchor: range.from,
-        head: range.to
+        anchor: error.from,
+        head: error.to
       }
     });
     rsInput.current?.view?.focus();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hover tooltips now include and highlight relevant rslang errors, showing error details and separators when present.

* **Refactor**
  * Editor selection and error-highlight logic simplified to rely on reported error positions for more consistent behavior.

* **Tests**
  * Added a negative semantic test case to improve error detection coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->