### PR TITLE
F: Add alias validation to JSON imports

### DIFF
--- a/rsconcept/backend/apps/rsform/models/api_RSLanguage.py
+++ b/rsconcept/backend/apps/rsform/models/api_RSLanguage.py
@@ -3,6 +3,8 @@ import re
 from enum import IntEnum, unique
 from typing import cast
 
+from shared import messages as msg
+
 from .Constituenta import CstType
 
 _RE_TEMPLATE = r'R\d+'
@@ -69,6 +71,30 @@ def guess_type(alias: str) -> CstType:
         if prefix == get_type_prefix(value):
             return cast(CstType, value)
     return CstType.BASE
+
+
+def validate_alias_format(alias: str, cst_type: str) -> bool:
+    ''' Check alias matches CstType naming rules (prefix + digits, min length 2). '''
+    if len(alias) < 2:
+        return False
+    prefix = get_type_prefix(cst_type)
+    if not alias.startswith(prefix):
+        return False
+    suffix = alias[len(prefix):]
+    return suffix.isdigit()
+
+
+def find_import_alias_error(items: list[dict]) -> str | None:
+    ''' Return first alias validation error for imported constituents, or None. '''
+    seen: set[str] = set()
+    for item in items:
+        alias = item['alias']
+        if alias in seen:
+            return msg.aliasDuplicate(alias)
+        seen.add(alias)
+        if not validate_alias_format(alias, item['cst_type']):
+            return msg.aliasInvalidFormat(alias)
+    return None
 
 
 def infer_template(expression: str) -> bool:

--- a/rsconcept/backend/apps/rsform/serializers/data_access.py
+++ b/rsconcept/backend/apps/rsform/serializers/data_access.py
@@ -18,10 +18,11 @@ from shared import messages as msg
 from shared.serializers import (
     PortalImportJsonMetadataSerializer,
     StrictModelSerializer,
-    StrictSerializer,
+    StrictSerializer
 )
 
 from ..models import Attribution, Constituenta, CstType, RSForm
+from ..models.api_RSLanguage import find_import_alias_error
 from .basics import CstParseSerializer, InheritanceDataSerializer
 
 
@@ -107,6 +108,13 @@ class RSFormImportJsonSerializer(PortalImportJsonMetadataSerializer):
     ''' Serializer: versioned RSForm data for importing into an existing schema. '''
     items = CstImportJsonSerializer(many=True)
     attribution = AttributionSerializer(many=True, required=False)
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        alias_error = find_import_alias_error(attrs['items'])
+        if alias_error:
+            raise serializers.ValidationError({'items': alias_error})
+        return attrs
 
 
 class CstUpdateSerializer(StrictSerializer):

--- a/rsconcept/backend/apps/rsform/serializers/io_files.py
+++ b/rsconcept/backend/apps/rsform/serializers/io_files.py
@@ -7,6 +7,7 @@ from shared import messages as msg
 from shared.serializers import StrictSerializer
 
 from ..models import Attribution, Constituenta, CstType, RSFormCached
+from ..models.api_RSLanguage import find_import_alias_error
 from ..utils import fix_old_references
 
 _ENTITY_CONSTITUENTA = 'constituenta'
@@ -258,6 +259,10 @@ class RSFormSandboxImportSerializer(StrictSerializer):
                 raise serializers.ValidationError({
                     'schema_data': 'Attributions must reference imported constituents'
                 })
+
+        alias_error = find_import_alias_error(attrs['schema_data']['items'])
+        if alias_error:
+            raise serializers.ValidationError({'schema_data': alias_error})
         return attrs
 
     @transaction.atomic

--- a/rsconcept/backend/apps/rsform/tests/s_views/t_rsforms.py
+++ b/rsconcept/backend/apps/rsform/tests/s_views/t_rsforms.py
@@ -117,6 +117,45 @@ class TestRSFormViewset(EndpointTester):
         }
         self.executeBadData(data)
 
+    @decl_endpoint('/api/rsforms/create-from-sandbox', method='post')
+    def test_create_rsform_from_sandbox_rejects_duplicate_alias(self):
+        duplicate_alias = 'X1'
+        base_item = {
+            'convention': '',
+            'crucial': False,
+            'definition_formal': '',
+            'definition_raw': '',
+            'definition_resolved': '',
+            'term_raw': '',
+            'term_resolved': '',
+            'term_forms': []
+        }
+        data = {
+            'item_data': {
+                'title': 'Sandbox schema',
+                'alias': 'SB3',
+                'description': '',
+            },
+            'schema_data': {
+                'items': [
+                    {
+                        **base_item,
+                        'id': 301,
+                        'alias': duplicate_alias,
+                        'cst_type': CstType.BASE,
+                    },
+                    {
+                        **base_item,
+                        'id': 302,
+                        'alias': duplicate_alias,
+                        'cst_type': CstType.BASE,
+                    }
+                ],
+                'attribution': []
+            }
+        }
+        self.executeBadData(data)
+
 
     @decl_endpoint('/api/rsforms', method='get')
     def test_list_rsforms(self):
@@ -235,6 +274,36 @@ class TestRSFormViewset(EndpointTester):
             'items': [{**data['items'][0], 'alias': 'D1'}]
         }
         self.executeBadData(item=self.owned_id, data=bad_alias)
+
+    @decl_endpoint('/api/rsforms/{item}/load-json', method='patch')
+    def test_load_json_rejects_duplicate_alias(self):
+        duplicate_alias = 'X1'
+        x1 = self.owned.insert_last(alias='X1')
+        x2 = self.owned.insert_last(alias='X2')
+        base_item = {
+            'convention': '',
+            'crucial': False,
+            'definition_formal': '',
+            'typification_manual': '',
+            'value_is_property': False,
+            'definition_raw': '',
+            'definition_resolved': '',
+            'term_raw': '',
+            'term_resolved': '',
+            'term_forms': []
+        }
+        data = {
+            'contract_version': PORTAL_JSON_CONTRACT_VERSION,
+            'title': 'Imported title',
+            'alias': 'IMP',
+            'description': 'Imported description',
+            'items': [
+                {**base_item, 'id': x1.pk, 'alias': duplicate_alias, 'cst_type': CstType.BASE},
+                {**base_item, 'id': x2.pk, 'alias': duplicate_alias, 'cst_type': CstType.BASE},
+            ],
+            'attribution': []
+        }
+        self.executeBadData(item=self.owned_id, data=data)
 
 
     @decl_endpoint('/api/rsforms/{item}/details', method='get')

--- a/rsconcept/backend/apps/rsform/tests/s_views/t_rsforms.py
+++ b/rsconcept/backend/apps/rsform/tests/s_views/t_rsforms.py
@@ -90,6 +90,33 @@ class TestRSFormViewset(EndpointTester):
         Attribution = created.constituentsQ().model._meta.apps.get_model('rsform', 'Attribution')
         self.assertEqual(Attribution.objects.filter(container__schema_id=created.model.pk).count(), 1)
 
+    @decl_endpoint('/api/rsforms/create-from-sandbox', method='post')
+    def test_create_rsform_from_sandbox_rejects_invalid_alias(self):
+        data = {
+            'item_data': {
+                'title': 'Sandbox schema',
+                'alias': 'SB2',
+                'description': '',
+            },
+            'schema_data': {
+                'items': [{
+                    'id': 201,
+                    'alias': 'D1',
+                    'convention': '',
+                    'crucial': False,
+                    'cst_type': CstType.BASE,
+                    'definition_formal': '',
+                    'definition_raw': '',
+                    'definition_resolved': '',
+                    'term_raw': '',
+                    'term_resolved': '',
+                    'term_forms': []
+                }],
+                'attribution': []
+            }
+        }
+        self.executeBadData(data)
+
 
     @decl_endpoint('/api/rsforms', method='get')
     def test_list_rsforms(self):
@@ -202,6 +229,12 @@ class TestRSFormViewset(EndpointTester):
         self.executeBadData(item=self.owned_id, data={'items': [{}]})
         bad_version = {**data, 'contract_version': '0.0.0'}
         self.executeBadData(item=self.owned_id, data=bad_version)
+
+        bad_alias = {
+            **data,
+            'items': [{**data['items'][0], 'alias': 'D1'}]
+        }
+        self.executeBadData(item=self.owned_id, data=bad_alias)
 
 
     @decl_endpoint('/api/rsforms/{item}/details', method='get')

--- a/rsconcept/backend/shared/messages.py
+++ b/rsconcept/backend/shared/messages.py
@@ -2,209 +2,217 @@
 # pylint: skip-file
 
 
-def fieldNotAllowed():
+def fieldNotAllowed() -> str:
     return 'Недопустимое поле'
 
 
-def constituentsInvalid(constituents: list[int]):
+def constituentsInvalid(constituents: list[int]) -> str:
     return f'некорректные конституенты для схемы: {constituents}'
 
 
-def associationSelf():
+def associationSelf() -> str:
     return 'Рефлексивная ассоциация не допускается'
 
 
-def associationAlreadyExists():
+def associationAlreadyExists() -> str:
     return 'Отношение уже существует'
 
 
-def constituentaNotInRSform(title: str):
+def constituentaNotInRSform(title: str) -> str:
     return f'Конституента не принадлежит схеме: {title}'
 
 
-def changeInheritedDefinition():
+def changeInheritedDefinition() -> str:
     return 'Нельзя изменить определение наследника'
 
 
-def constituentaNotFromOperation():
+def constituentaNotFromOperation() -> str:
     return 'Конституента не соответствую аргументам операции'
 
 
-def operationNotInOSS():
+def operationNotInOSS() -> str:
     return 'Операция не принадлежит ОСС'
 
 
-def operationResultNotInOSS():
+def operationResultNotInOSS() -> str:
     return 'Результат операции не принадлежит ОСС'
 
 
-def duplicateSchemasInArguments():
+def duplicateSchemasInArguments() -> str:
     return 'Аргументы не должны содержать повторяющиеся КС'
 
 
-def blockNotInOSS():
+def blockNotInOSS() -> str:
     return 'Блок не принадлежит ОСС'
 
 
-def parentNotInOSS():
+def parentNotInOSS() -> str:
     return 'Родительский блок не принадлежит ОСС'
 
 
-def blockCyclicHierarchy():
+def blockCyclicHierarchy() -> str:
     return 'Попытка создания циклического вложения'
 
 
-def childNotInOSS():
+def childNotInOSS() -> str:
     return f'Дочерний элемент блок не принадлежит ОСС'
 
 
-def missingArguments():
+def missingArguments() -> str:
     return 'Операция не содержит аргументов, при этом содержит отождествления'
 
 
-def exteorFileCorrupted():
+def exteorFileCorrupted() -> str:
     return 'Файл Экстеор не соответствует ожидаемому формату. Попробуйте сохранить файл в новой версии'
 
 
-def importIntoInherited():
+def importIntoInherited() -> str:
     return 'Нельзя импортировать в синтезированную КС'
 
 
-def previousResultMissing():
+def previousResultMissing() -> str:
     return 'Отсутствует результат предыдущей операции'
 
 
-def substitutionNotInList():
+def substitutionNotInList() -> str:
     return 'Отождествляемая конституента отсутствует в списке'
 
 
-def schemaForbidden():
+def schemaForbidden() -> str:
     return 'Нет доступа к схеме'
 
 
-def operationNotInput(title: str):
+def operationNotInput(title: str) -> str:
     return f'Операция не является Загрузкой: {title}'
 
 
-def operationHasArguments(title: str):
+def operationHasArguments(title: str) -> str:
     return f'Операция имеет аргументы: {title}'
 
 
-def operationResultFromAnotherOSS():
+def operationResultFromAnotherOSS() -> str:
     return 'Схема является результатом другой ОСС'
 
 
-def schemasNotConnected():
+def schemasNotConnected() -> str:
     return 'Концептуальные схемы не связаны через ОСС'
 
 
-def sourceEqualDestination():
+def sourceEqualDestination() -> str:
     return 'Схема-источник и схема-получатель не могут быть одинаковыми'
 
 
-def RelocatingInherited():
+def RelocatingInherited() -> str:
     return 'Невозможно переместить наследуемые конституенты'
 
 
-def operationInputAlreadyConnected():
+def operationInputAlreadyConnected() -> str:
     return 'Схема уже подключена к другой операции'
 
 
-def replicaNotAllowed():
+def replicaNotAllowed() -> str:
     return 'Реплики не поддерживаются'
 
 
-def replicaRequired():
+def replicaRequired() -> str:
     return 'Операция должна быть репликацией'
 
 
-def operationNotSynthesis(title: str):
+def operationNotSynthesis(title: str) -> str:
     return f'Операция не является Синтезом: {title}'
 
 
-def operationResultEmpty(title: str):
+def operationResultEmpty(title: str) -> str:
     return f'Результат операции пуст: {title}'
 
 
-def operationResultNotEmpty(title: str):
+def operationResultNotEmpty(title: str) -> str:
     return f'Результат операции не пуст: {title}'
 
 
-def renameTrivial(name: str):
+def renameTrivial(name: str) -> str:
     return f'Имя должно отличаться от текущего: {name}'
 
 
-def substituteTrivial(name: str):
+def substituteTrivial(name: str) -> str:
     return f'Отождествление конституенты с собой не корректно: {name}'
 
 
-def substituteDouble(name: str):
+def substituteDouble(name: str) -> str:
     return f'Повторное отождествление: {name}'
 
 
-def aliasTaken(name: str):
+def aliasTaken(name: str) -> str:
     return f'Имя уже используется: {name}'
 
 
-def invalidLocation():
+def aliasInvalidFormat(name: str) -> str:
+    return f'Некорректное имя конституенты: {name}'
+
+
+def aliasDuplicate(name: str) -> str:
+    return f'Повторяющееся имя конституенты: {name}'
+
+
+def invalidLocation() -> str:
     return f'Некорректная строка расположения'
 
 
-def invalidEnum(value: str):
+def invalidEnum(value: str) -> str:
     return f'Неподдерживаемое значение параметра: {value}'
 
 
-def typificationInvalidStr():
+def typificationInvalidStr() -> str:
     return 'Invalid typification string'
 
 
-def missingAttribution():
+def missingAttribution() -> str:
     return f'Атрибутирование не найдено'
 
 
-def deleteInheritedAttribution():
+def deleteInheritedAttribution() -> str:
     return f'Попытка удалить наследованное атрибутирование'
 
 
-def createdInheritedAttribution():
+def createdInheritedAttribution() -> str:
     return f'Попытка установить атрибутирование между наследниками из одной КС'
 
 
-def exteorFileVersionNotSupported():
+def exteorFileVersionNotSupported() -> str:
     return 'Некорректный формат файла Экстеор. Сохраните файл в новой версии'
 
 
-def constituentaNoStructure():
+def constituentaNoStructure() -> str:
     return 'Указанная конституента не обладает теоретико-множественной типизацией'
 
 
-def missingFile():
+def missingFile() -> str:
     return 'Отсутствует прикрепленный файл'
 
 
-def passwordAuthFailed():
+def passwordAuthFailed() -> str:
     return 'Неизвестное сочетание имени пользователя (email) и пароля'
 
 
-def passwordsNotMatch():
+def passwordsNotMatch() -> str:
     return 'Введенные пароли не совпадают'
 
 
-def emailAlreadyTaken():
+def emailAlreadyTaken() -> str:
     return 'Пользователь с данным email уже существует'
 
 
-def promptLabelTaken(label: str):
+def promptLabelTaken(label: str) -> str:
     return f'Шаблон с меткой "{label}" уже существует у пользователя.'
 
 
-def promptNotOwner():
+def promptNotOwner() -> str:
     return 'Вы не являетесь владельцем этого шаблона.'
 
 
-def promptSharedPermissionDenied():
+def promptSharedPermissionDenied() -> str:
     return 'Только администратор может сделать шаблон общедоступным.'
 
 
-def promptNotFound():
+def promptNotFound() -> str:
     return 'Шаблон не найден.'

--- a/rsconcept/backend/shared/messages.py
+++ b/rsconcept/backend/shared/messages.py
@@ -55,7 +55,7 @@ def blockCyclicHierarchy() -> str:
 
 
 def childNotInOSS() -> str:
-    return f'Дочерний элемент блок не принадлежит ОСС'
+    return 'Дочерний элемент блок не принадлежит ОСС'
 
 
 def missingArguments() -> str:

--- a/rsconcept/frontend/package-lock.json
+++ b/rsconcept/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "@lezer/highlight": "^1.2.3",
         "@lezer/lr": "^1.4.10",
         "@react-pdf/renderer": "^4.5.1",
-        "@rsconcept/domain": "^1.0.0",
+        "@rsconcept/domain": "^1.1.0",
         "@sentry/react": "^10.57.0",
         "@tanstack/react-form": "^1.33.0",
         "@tanstack/react-query": "^5.101.0",
@@ -3027,9 +3027,9 @@
       }
     },
     "node_modules/@rsconcept/domain": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rsconcept/domain/-/domain-1.0.0.tgz",
-      "integrity": "sha512-YtOJ0g6khm7X6QQS57QMqR3s8BMMxtg1fAjESvB3808R57ZreabOvWD+lrpNPAcYyjUg4pUnQ9gTPKpJ93ingw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rsconcept/domain/-/domain-1.1.0.tgz",
+      "integrity": "sha512-UNxQ7+02B45nKN3r8oqN7pR/3NsCboTH2mBcMmYz2WKDe0/60hu3Iuj0nAOxRLIqBSuY/iKcqB609sx5gA9A/A==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.5.2",

--- a/rsconcept/frontend/package.json
+++ b/rsconcept/frontend/package.json
@@ -30,7 +30,7 @@
     "@lezer/highlight": "^1.2.3",
     "@lezer/lr": "^1.4.10",
     "@react-pdf/renderer": "^4.5.1",
-    "@rsconcept/domain": "^1.0.0",
+    "@rsconcept/domain": "^1.1.0",
     "@sentry/react": "^10.57.0",
     "@tanstack/react-form": "^1.33.0",
     "@tanstack/react-query": "^5.101.0",

--- a/rsconcept/frontend/src/features/rsform/backend/types.ts
+++ b/rsconcept/frontend/src/features/rsform/backend/types.ts
@@ -9,6 +9,8 @@ import { schemaPortalImportMetadata } from '@/features/library/models/portal-imp
 
 import { limits } from '@/utils/constants';
 
+import { validateImportedAliases } from '../models/json-file';
+
 /** Represents Constituenta basic persistent data. */
 export type ConstituentaBasicsDTO = z.infer<typeof schemaConstituentaBasics>;
 
@@ -97,10 +99,17 @@ export const schemaAttribution = z.strictObject({
   attribute: z.number()
 });
 
-export const schemaRSFormImportJson = schemaPortalImportMetadata.extend({
-  items: z.array(schemaConstituentaBasics),
-  attribution: z.array(schemaAttribution).optional()
-});
+export const schemaRSFormImportJson = schemaPortalImportMetadata
+  .extend({
+    items: z.array(schemaConstituentaBasics),
+    attribution: z.array(schemaAttribution).optional()
+  })
+  .superRefine((data, ctx) => {
+    const error = validateImportedAliases(data.items);
+    if (error) {
+      ctx.addIssue({ code: 'custom', message: error });
+    }
+  });
 
 export const schemaRSForm = schemaLibraryItem.extend({
   is_produced: z.boolean(),

--- a/rsconcept/frontend/src/features/rsform/models/json-file.ts
+++ b/rsconcept/frontend/src/features/rsform/models/json-file.ts
@@ -1,19 +1,27 @@
 import { globalTx } from '@/i18n';
-import { type CstType, type RSForm } from '@rsconcept/domain/library';
+import { type CstType } from '@rsconcept/domain/library';
 import { validateAliasFormat } from '@rsconcept/domain/library/rsform-api';
 
 import { PORTAL_JSON_CONTRACT_VERSION } from '@/features/library/models/portal-import-json';
 
-import { type RSFormImportJsonDTO } from '../backend/types';
+import { type ConstituentaBasicsDTO, type RSFormImportJsonDTO } from '../backend/types';
 
-/** Build Portal schema JSON import payload from the current schema state. */
-export function toRSFormImportJson(schema: RSForm): RSFormImportJsonDTO {
+interface RSFormImportContent {
+  title: string;
+  alias: string;
+  description: string;
+  items: readonly ConstituentaBasicsDTO[];
+  attribution: readonly { container: number; attribute: number }[];
+}
+
+/** Build Portal schema JSON import payload from schema content. */
+export function rsFormContentToImportJson(content: RSFormImportContent): RSFormImportJsonDTO {
   return {
     contract_version: PORTAL_JSON_CONTRACT_VERSION,
-    title: schema.title,
-    alias: schema.alias,
-    description: schema.description,
-    items: schema.items.map(cst => ({
+    title: content.title,
+    alias: content.alias,
+    description: content.description,
+    items: content.items.map(cst => ({
       id: cst.id,
       alias: cst.alias,
       convention: cst.convention,
@@ -28,7 +36,7 @@ export function toRSFormImportJson(schema: RSForm): RSFormImportJsonDTO {
       term_resolved: cst.term_resolved,
       term_forms: cst.term_forms
     })),
-    attribution: schema.attribution.map(({ container, attribute }) => ({ container, attribute }))
+    attribution: content.attribution.map(({ container, attribute }) => ({ container, attribute }))
   };
 }
 

--- a/rsconcept/frontend/src/features/rsform/models/json-file.ts
+++ b/rsconcept/frontend/src/features/rsform/models/json-file.ts
@@ -1,4 +1,6 @@
-import { type RSForm } from '@rsconcept/domain/library';
+import { globalTx } from '@/i18n';
+import { type CstType, type RSForm } from '@rsconcept/domain/library';
+import { validateAliasFormat } from '@rsconcept/domain/library/rsform-api';
 
 import { PORTAL_JSON_CONTRACT_VERSION } from '@/features/library/models/portal-import-json';
 
@@ -28,4 +30,24 @@ export function toRSFormImportJson(schema: RSForm): RSFormImportJsonDTO {
     })),
     attribution: schema.attribution.map(({ container, attribute }) => ({ container, attribute }))
   };
+}
+
+interface ImportConstituenta {
+  alias: string;
+  cst_type: CstType;
+}
+
+/** Return a user-facing error when imported constituents have invalid or duplicate aliases. */
+export function validateImportedAliases(items: readonly ImportConstituenta[]): string | null {
+  const seen = new Set<string>();
+  for (const item of items) {
+    if (seen.has(item.alias)) {
+      return globalTx('tx.cst.alias.validate.import.duplicate', { alias: item.alias });
+    }
+    seen.add(item.alias);
+    if (!validateAliasFormat(item.alias, item.cst_type)) {
+      return globalTx('tx.cst.alias.validate.import.format', { alias: item.alias });
+    }
+  }
+  return null;
 }

--- a/rsconcept/frontend/src/features/rsform/models/parse-import-json.test.ts
+++ b/rsconcept/frontend/src/features/rsform/models/parse-import-json.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { globalTx } from '@/i18n';
+import { CstType } from '@rsconcept/domain/library';
+
+import { PORTAL_JSON_CONTRACT_VERSION } from '@/features/library/models/portal-import-json';
+import starterEn from '@/features/sandbox/models/starter-bundles/starter-bundle.en.json';
+
+import { parseRSFormImportJson } from './parse-import-json';
+
+describe('parseRSFormImportJson', () => {
+  it('accepts Portal schema JSON export', () => {
+    const payload = {
+      contract_version: PORTAL_JSON_CONTRACT_VERSION,
+      title: 'Test schema',
+      alias: 'TS1',
+      description: 'desc',
+      items: [
+        {
+          id: 1,
+          alias: 'X1',
+          convention: '',
+          crucial: false,
+          cst_type: CstType.BASE,
+          definition_formal: '',
+          typification_manual: '',
+          value_is_property: false,
+          definition_raw: '',
+          definition_resolved: '',
+          term_raw: '',
+          term_resolved: '',
+          term_forms: []
+        }
+      ],
+      attribution: []
+    };
+
+    expect(parseRSFormImportJson(payload)).toEqual(payload);
+  });
+
+  it('accepts sandbox bundle JSON export', () => {
+    const parsed = parseRSFormImportJson(starterEn);
+
+    expect(parsed.contract_version).toBe(PORTAL_JSON_CONTRACT_VERSION);
+    expect(parsed.title).toBe(starterEn.schema.title);
+    expect(parsed.alias).toBe(starterEn.schema.alias);
+    expect(parsed.description).toBe(starterEn.schema.description);
+    expect(parsed.items).toHaveLength(starterEn.schema.items.length);
+    expect(parsed.items[0]?.alias).toBe(starterEn.schema.items[0]?.alias);
+    expect(parsed.items[0]?.typification_manual).toBe('');
+    expect(parsed.items[0]?.value_is_property).toBe(false);
+    expect(parsed.attribution).toEqual(starterEn.schema.attribution);
+  });
+
+  it('rejects unknown JSON shape', () => {
+    expect(() => parseRSFormImportJson({ foo: 'bar' })).toThrow(globalTx('tx.schema.upload.json.invalid'));
+  });
+
+  it('rejects sandbox bundle with invalid alias', () => {
+    const invalid = structuredClone(starterEn);
+    invalid.schema.items[0] = { ...invalid.schema.items[0], alias: 'D1', cst_type: CstType.BASE };
+
+    expect(() => parseRSFormImportJson(invalid)).toThrow();
+  });
+});

--- a/rsconcept/frontend/src/features/rsform/models/parse-import-json.ts
+++ b/rsconcept/frontend/src/features/rsform/models/parse-import-json.ts
@@ -1,0 +1,43 @@
+import { globalTx } from '@/i18n';
+
+import { schemaSandboxBundle } from '@/features/sandbox/models/bundle';
+
+import { type RSFormImportJsonDTO, schemaRSFormImportJson } from '../backend/types';
+
+import { rsFormContentToImportJson } from './json-file';
+
+function isRecord(raw: unknown): raw is Record<string, unknown> {
+  return typeof raw === 'object' && raw !== null;
+}
+
+function firstIssueMessage(error: { issues: { message?: string }[] }, fallback: string): string {
+  return error.issues[0]?.message ?? fallback;
+}
+
+/** Parse Portal schema JSON export or sandbox bundle JSON into a load-json payload. */
+export function parseRSFormImportJson(raw: unknown): RSFormImportJsonDTO {
+  const portal = schemaRSFormImportJson.safeParse(raw);
+  if (portal.success) {
+    return portal.data;
+  }
+
+  const bundle = schemaSandboxBundle.safeParse(raw);
+  if (bundle.success) {
+    return rsFormContentToImportJson(bundle.data.schema);
+  }
+
+  if (isRecord(raw) && 'contract_version' in raw) {
+    throw new Error(firstIssueMessage(portal.error, globalTx('tx.schema.upload.json.invalid')));
+  }
+  if (isRecord(raw) && 'formatVersion' in raw) {
+    throw new Error(firstIssueMessage(bundle.error, globalTx('tx.sandbox.bundle.load.file.invalid')));
+  }
+
+  throw new Error(globalTx('tx.schema.upload.json.invalid'));
+}
+
+/** Read a JSON file with Portal schema export or sandbox bundle data. */
+export async function readRSFormImportJsonFile(file: File): Promise<RSFormImportJsonDTO> {
+  const payload = JSON.parse(await file.text()) as unknown;
+  return parseRSFormImportJson(payload);
+}

--- a/rsconcept/frontend/src/features/rsform/pages/rsform-page/menu-main.tsx
+++ b/rsconcept/frontend/src/features/rsform/pages/rsform-page/menu-main.tsx
@@ -34,12 +34,12 @@ import {
 import { useDialogsStore } from '@/stores/dialogs';
 import { useModificationStore } from '@/stores/modification';
 import { EXTEOR_TRS_FILE, prefixes } from '@/utils/constants';
-import { convertToJSON, generatePageQR, readJsonFile, sharePage } from '@/utils/utils';
+import { convertToJSON, generatePageQR, sharePage } from '@/utils/utils';
 
-import { schemaRSFormImportJson } from '../../backend/types';
 import { useUploadRSFormJson } from '../../backend/use-upload-json';
 import { useUploadTRS } from '../../backend/use-upload-trs';
-import { toRSFormImportJson } from '../../models/json-file';
+import { rsFormContentToImportJson } from '../../models/json-file';
+import { readRSFormImportJsonFile } from '../../models/parse-import-json';
 import { prepareTRSFile } from '../../models/trs-file';
 
 import { useSchemaEdit } from './schema-edit-context';
@@ -124,7 +124,7 @@ export function MenuMain() {
       }
     }
     try {
-      const payload = toRSFormImportJson(schema);
+      const payload = rsFormContentToImportJson(schema);
       fileDownload(convertToJSON(payload), `${schema.alias ?? 'Schema'}.json`, 'application/json;charset=utf-8;');
     } catch (error) {
       console.error(error);
@@ -164,7 +164,7 @@ export function MenuMain() {
     }
     let data;
     try {
-      data = await readJsonFile(file, schemaRSFormImportJson);
+      data = await readRSFormImportJsonFile(file);
     } catch (error) {
       toast.error((error as Error).message);
       console.error(error);

--- a/rsconcept/frontend/src/features/sandbox/models/bundle-schema.test.ts
+++ b/rsconcept/frontend/src/features/sandbox/models/bundle-schema.test.ts
@@ -9,6 +9,15 @@ import starterEn from './starter-bundles/starter-bundle.en.json';
 import { schemaSandboxBundle } from './bundle';
 import { createStarterSandboxBundle } from './bundle-starter';
 
+describe('sandbox bundle / constituent alias validation', () => {
+  it('rejects bundle with alias that does not match cst_type', () => {
+    const invalid = structuredClone(starterEn);
+    invalid.schema.items[0] = { ...invalid.schema.items[0], alias: 'D1', cst_type: CstType.BASE };
+    const parsed = schemaSandboxBundle.safeParse(invalid);
+    expect(parsed.success).toBe(false);
+  });
+});
+
 describe('sandbox bundle / DTO migration for typification_manual', () => {
   it('parses starter locale JSON (items omit typification_manual)', () => {
     const bundle = schemaSandboxBundle.parse(starterEn);

--- a/rsconcept/frontend/src/features/sandbox/models/bundle.ts
+++ b/rsconcept/frontend/src/features/sandbox/models/bundle.ts
@@ -1,18 +1,26 @@
 import { z } from 'zod';
 
 import { schemaRSForm } from '@/features/rsform';
+import { validateImportedAliases } from '@/features/rsform/models/json-file';
 import { schemaRSModel } from '@/features/rsmodel';
 
 export const SANDBOX_BUNDLE_FORMAT_VERSION = 2 as const;
 
-export const schemaSandboxBundle = z.strictObject({
-  formatVersion: z.literal(SANDBOX_BUNDLE_FORMAT_VERSION),
-  meta: z.strictObject({
-    nextId: z.number().int().positive(),
-    updatedAt: z.string()
-  }),
-  schema: schemaRSForm,
-  model: schemaRSModel
-});
+export const schemaSandboxBundle = z
+  .strictObject({
+    formatVersion: z.literal(SANDBOX_BUNDLE_FORMAT_VERSION),
+    meta: z.strictObject({
+      nextId: z.number().int().positive(),
+      updatedAt: z.string()
+    }),
+    schema: schemaRSForm,
+    model: schemaRSModel
+  })
+  .superRefine((data, ctx) => {
+    const error = validateImportedAliases(data.schema.items);
+    if (error) {
+      ctx.addIssue({ code: 'custom', message: error });
+    }
+  });
 
 export type SandboxBundle = z.infer<typeof schemaSandboxBundle>;

--- a/rsconcept/frontend/src/features/sandbox/pages/sandbox-editor/menu-main.tsx
+++ b/rsconcept/frontend/src/features/sandbox/pages/sandbox-editor/menu-main.tsx
@@ -127,7 +127,8 @@ export function MenuMain() {
       toast.success(tx('tx.sandbox.import.success'));
     } catch (error) {
       console.error(error);
-      toast.error(tx('tx.sandbox.import.fail'));
+      const message = error instanceof Error ? error.message : tx('tx.sandbox.import.fail');
+      toast.error(message);
     }
   }
 

--- a/rsconcept/frontend/src/features/sandbox/stores/sandbox-repository.ts
+++ b/rsconcept/frontend/src/features/sandbox/stores/sandbox-repository.ts
@@ -59,7 +59,8 @@ export function downloadBundle(bundle: SandboxBundle, filename: string = DEFAULT
 function parseBundleJson(raw: unknown): SandboxBundle {
   const parsed = schemaSandboxBundle.safeParse(raw);
   if (!parsed.success) {
-    throw new Error(globalTx('tx.sandbox.bundle.load.file.invalid'));
+    const message = parsed.error.issues[0]?.message ?? globalTx('tx.sandbox.bundle.load.file.invalid');
+    throw new Error(message);
   }
   return parsed.data;
 }

--- a/rsconcept/frontend/src/i18n/domain/library.en.ts
+++ b/rsconcept/frontend/src/i18n/domain/library.en.ts
@@ -224,6 +224,8 @@ export const txLibraryEn: Record<string, string> = {
   'tx.cst.new': 'New constituent',
   'tx.cst.attribute.plural': 'Attributes of a constituenta',
   'tx.cst.alias.validate': 'Enter an unused name that matches the type',
+  'tx.cst.alias.validate.import.format': 'Constituent alias does not match type: {alias}',
+  'tx.cst.alias.validate.import.duplicate': 'Duplicate constituent alias: {alias}',
   'tx.cst.original.plural.short': 'Original',
   'tx.cst.original.hint': 'Concepts added in this schema (not inherited)',
   'tx.cst.original.select': 'Select original',

--- a/rsconcept/frontend/src/i18n/domain/library.en.ts
+++ b/rsconcept/frontend/src/i18n/domain/library.en.ts
@@ -162,6 +162,7 @@ export const txLibraryEn: Record<string, string> = {
   'tx.schema.select': 'Select schema',
   'tx.schema.upload.attributes': 'Load title and comment from file',
   'tx.schema.upload.constituents': 'Loading from a file will remove all constituents of the current conceptual schema.',
+  'tx.schema.upload.json.invalid': 'File is not a valid schema or sandbox JSON export.',
   'tx.schema.upload.success': 'Schema loaded',
   'tx.schema.inherit.owner': 'Owner inherited from OSS',
   'tx.schema.inherit.location': 'Path inherited from OSS',

--- a/rsconcept/frontend/src/i18n/domain/library.fr.ts
+++ b/rsconcept/frontend/src/i18n/domain/library.fr.ts
@@ -227,6 +227,8 @@ export const txLibraryFr: Record<string, string> = {
   'tx.cst.new': 'Nouvelle constituante',
   'tx.cst.attribute.plural': 'Attributs de la constituante',
   'tx.cst.alias.validate': 'Entrez un nom non utilisé qui correspond au type',
+  'tx.cst.alias.validate.import.format': "L'abréviation de la constituante ne correspond pas au type : {alias}",
+  'tx.cst.alias.validate.import.duplicate': 'Abréviation de constituante en double : {alias}',
   'tx.cst.original.plural.short': 'Originales',
   'tx.cst.original.hint': 'Concepts ajoutés dans ce schéma (non hérités)',
   'tx.cst.original.select': 'Sélectionner les originales',

--- a/rsconcept/frontend/src/i18n/domain/library.fr.ts
+++ b/rsconcept/frontend/src/i18n/domain/library.fr.ts
@@ -165,6 +165,7 @@ export const txLibraryFr: Record<string, string> = {
   'tx.schema.upload.attributes': 'Charger le titre et le commentaire',
   'tx.schema.upload.constituents':
     'En important depuis un fichier, toutes les constituantes du schéma actuel seront supprimées',
+  'tx.schema.upload.json.invalid': 'Le fichier n’est pas une exportation JSON valide de schéma ou de bac à sable.',
   'tx.schema.upload.success': 'Schéma chargé',
   'tx.schema.inherit.owner': 'Propriétaire hérité de l’OSS',
   'tx.schema.inherit.location': 'Chemin hérité de l’OSS',

--- a/rsconcept/frontend/src/i18n/domain/library.ru.ts
+++ b/rsconcept/frontend/src/i18n/domain/library.ru.ts
@@ -166,6 +166,7 @@ export const txLibraryRu: Record<string, string> = {
   'tx.schema.select': 'Выбор схемы',
   'tx.schema.upload.attributes': 'Загружать название и комментарий',
   'tx.schema.upload.constituents': 'При загрузке из файла все конституенты текущей КС будут удалены',
+  'tx.schema.upload.json.invalid': 'Файл не является корректной выгрузкой схемы или песочницы в JSON.',
   'tx.schema.upload.success': 'Схема загружена',
   'tx.schema.inherit.owner': 'Владелец наследуется от ОСС',
   'tx.schema.inherit.location': 'Путь наследуется от ОСС',

--- a/rsconcept/frontend/src/i18n/domain/library.ru.ts
+++ b/rsconcept/frontend/src/i18n/domain/library.ru.ts
@@ -228,6 +228,8 @@ export const txLibraryRu: Record<string, string> = {
   'tx.cst.new': 'Новая конституента',
   'tx.cst.attribute.plural': 'Атрибуты конституенты',
   'tx.cst.alias.validate': 'Введите незанятое имя,\nсоответствующее типу',
+  'tx.cst.alias.validate.import.format': 'Имя конституенты не соответствует типу: {alias}',
+  'tx.cst.alias.validate.import.duplicate': 'Повторяющееся имя конституенты: {alias}',
   'tx.cst.original.plural.short': 'Собственные',
   'tx.cst.original.hint': 'Понятия, добавленные в данной схеме (не наследованные)',
   'tx.cst.original.select': 'Выделить собственные',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Validation of imported items now detects invalid alias formats and duplicate aliases with user-friendly error messages across supported languages.

* **Bug Fixes**
  * Import failures now report specific validation errors instead of generic error messages.

* **Tests**
  * Added test coverage for imported alias validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->