### PR TITLE
B: Fix -1 in page exports in pdf

### DIFF
--- a/rsconcept/frontend/src/components/pdf/CDocument.tsx
+++ b/rsconcept/frontend/src/components/pdf/CDocument.tsx
@@ -1,17 +1,18 @@
 import { Document, Font, Page } from '@react-pdf/renderer';
 
+import { pdfFontSrc } from './pdf-font-path';
 import { pdfs } from './pdf-styles';
 
 Font.register({
   family: 'ConceptText',
   fonts: [
-    { src: '/fonts/ConceptText-Regular.ttf', fontWeight: 'normal' },
-    { src: '/fonts/ConceptText-Bold.ttf', fontWeight: 'bold' }
+    { src: pdfFontSrc('ConceptText-Regular.ttf'), fontWeight: 'normal' },
+    { src: pdfFontSrc('ConceptText-Bold.ttf'), fontWeight: 'bold' }
   ]
 });
 Font.register({
   family: 'CodeMath',
-  fonts: [{ src: '/fonts/ConceptMath-Regular.ttf' }]
+  fonts: [{ src: pdfFontSrc('ConceptMath-Regular.ttf') }]
 });
 
 const documentMetadata = {

--- a/rsconcept/frontend/src/components/pdf/pdf-font-path.test.ts
+++ b/rsconcept/frontend/src/components/pdf/pdf-font-path.test.ts
@@ -1,0 +1,13 @@
+import { existsSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { pdfFontSrc } from './pdf-font-path';
+
+describe('pdfFontSrc', () => {
+  it('resolves bundled fonts from the public directory in test mode', () => {
+    const fontPath = pdfFontSrc('ConceptText-Regular.ttf');
+
+    expect(fontPath).not.toMatch(/^\/fonts\//);
+    expect(existsSync(fontPath)).toBe(true);
+  });
+});

--- a/rsconcept/frontend/src/components/pdf/pdf-font-path.ts
+++ b/rsconcept/frontend/src/components/pdf/pdf-font-path.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from 'node:url';
+
+function publicFontPath(fileName: string): string {
+  return fileURLToPath(new URL(`../../../public/fonts/${fileName}`, import.meta.url));
+}
+
+/** Font URL for @react-pdf: web path in app, filesystem path under Vitest. */
+export function pdfFontSrc(fileName: string): string {
+  if (import.meta.env.MODE === 'test') {
+    return publicFontPath(fileName);
+  }
+  return `/fonts/${fileName}`;
+}

--- a/rsconcept/frontend/src/features/rsform/utils/pdf-utils.test.ts
+++ b/rsconcept/frontend/src/features/rsform/utils/pdf-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { addSpaces, hyphenateCyrillic, protectShortRussianWords } from './pdf-utils';
+import { addSpaces, formatPdfPageRange, hyphenateCyrillic, protectShortRussianWords } from './pdf-utils';
 
 describe('pdf-utils', () => {
   it('keeps formal expression spacing readable after removing soft wrap points', () => {
@@ -23,5 +23,18 @@ describe('pdf-utils', () => {
   it('never returns one-letter fragments for Cyrillic hyphenation', () => {
     expect(hyphenateCyrillic('индексация').every(part => part.length >= 2)).toBe(true);
     expect(hyphenateCyrillic('область').every(part => part.length >= 2)).toBe(true);
+  });
+
+  it('formats valid PDF page ranges', () => {
+    expect(formatPdfPageRange(1, 3)).toBe('1 / 3');
+    expect(formatPdfPageRange(3, 3)).toBe('3 / 3');
+  });
+
+  it('hides react-pdf layout placeholder page numbers', () => {
+    expect(formatPdfPageRange(-1, 5)).toBe('');
+    expect(formatPdfPageRange(0, 5)).toBe('');
+    expect(formatPdfPageRange(6, 5)).toBe('');
+    expect(formatPdfPageRange(1, 0)).toBe('');
+    expect(formatPdfPageRange(Number.NaN, 2)).toBe('');
   });
 });

--- a/rsconcept/frontend/src/features/rsform/utils/pdf-utils.ts
+++ b/rsconcept/frontend/src/features/rsform/utils/pdf-utils.ts
@@ -55,6 +55,21 @@ export function protectShortRussianWords(text: string): string {
 }
 
 /**
+ * Formats a page range for @react-pdf Text `render` callbacks.
+ * react-pdf may invoke the callback with placeholder values (-1, 0, totalPages + 1)
+ * during layout passes; those must not be written into the final PDF.
+ */
+export function formatPdfPageRange(pageNumber: number, totalPages: number): string {
+  if (!Number.isFinite(pageNumber) || !Number.isFinite(totalPages)) {
+    return '';
+  }
+  if (pageNumber < 1 || totalPages < 1 || pageNumber > totalPages) {
+    return '';
+  }
+  return `${pageNumber} / ${totalPages}`;
+}
+
+/**
  * Gives @react-pdf conservative hyphenation points for Cyrillic words.
  */
 export function hyphenateCyrillic(word: string): string[] {

--- a/rsconcept/frontend/src/features/rsform/utils/rsform2pdf.test.ts
+++ b/rsconcept/frontend/src/features/rsform/utils/rsform2pdf.test.ts
@@ -1,0 +1,128 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { type AppLocale } from '@/i18n';
+import { Graph } from '@rsconcept/domain/graph';
+import { type Constituenta, CstClass, CstType, type RSForm } from '@rsconcept/domain/library';
+
+type CreateSchemaFileFn = (data: RSForm) => Promise<Blob>;
+type CstListToFileFn = (data: Constituenta[]) => Promise<Blob>;
+
+let locale: AppLocale = 'ru';
+
+vi.mock('@/stores/preferences', () => ({
+  usePreferencesStore: {
+    getState: () => ({ locale }),
+    setState: (partial: { locale?: AppLocale }) => {
+      if (partial.locale) {
+        locale = partial.locale;
+      }
+    }
+  }
+}));
+
+function mockConstituenta(
+  partial: Pick<Constituenta, 'id' | 'alias' | 'definition_formal' | 'cst_class' | 'cst_type'> &
+    Partial<Pick<Constituenta, 'definition_resolved' | 'term_resolved' | 'convention'>>
+): Constituenta {
+  return {
+    schema: 1,
+    crucial: false,
+    convention: '',
+    definition_raw: '',
+    definition_resolved: '',
+    term_raw: '',
+    term_resolved: '',
+    term_forms: [],
+    typification_manual: '',
+    value_is_property: false,
+    homonyms: [],
+    formalDuplicates: [],
+    analysis: { success: true } as Constituenta['analysis'],
+    effectiveType: null,
+    is_type_mismatch: false,
+    status: 'verified',
+    is_template: false,
+    is_simple_expression: true,
+    parent_schema_index: 0,
+    parent_schema: null,
+    is_inherited: false,
+    has_inherited_children: false,
+    attributes: [],
+    spawn: [],
+    spawn_alias: [],
+    ...partial
+  };
+}
+
+function mockSchema(items: Constituenta[]): RSForm {
+  return {
+    id: 1,
+    title: 'Test schema',
+    alias: 'S1',
+    items,
+    graph: new Graph(items.map(item => [item.id]))
+  } as RSForm;
+}
+
+async function pdfBlobToLatin1Text(blob: Blob): Promise<string> {
+  const buffer = await blob.arrayBuffer();
+  return new TextDecoder('latin1').decode(buffer);
+}
+
+function assertNoInvalidPdfPageNumbers(pdfText: string): void {
+  expect(pdfText).not.toMatch(/(?:^|[\s(])(-1)\s*\/\s*\d/);
+}
+
+describe('rsform2pdf', () => {
+  let createSchemaFile: CreateSchemaFileFn;
+  let cstListToFile: CstListToFileFn;
+
+  beforeAll(async () => {
+    ({ createSchemaFile, cstListToFile } = await import('./rsform2pdf'));
+  });
+
+  it('does not embed invalid page numbers in schema PDF footers', async () => {
+    locale = 'ru';
+
+    const items = Array.from({ length: 40 }, (_, index) =>
+      mockConstituenta({
+        id: index + 1,
+        alias: `X${index + 1}`,
+        cst_class: CstClass.BASIC,
+        cst_type: CstType.BASE,
+        definition_formal: `[α∈ℬ(R)]Pr1(β${index})`,
+        definition_resolved:
+          'Длинное текстовое описание конституенты для переноса на следующие страницы PDF-документа.',
+        term_resolved: `термин ${index + 1}`
+      })
+    );
+
+    const blob = await createSchemaFile(mockSchema(items));
+    const pdfText = await pdfBlobToLatin1Text(blob);
+
+    assertNoInvalidPdfPageNumbers(pdfText);
+    expect(pdfText.length).toBeGreaterThan(0);
+  });
+
+  it('does not embed invalid page numbers in constituent list PDF footers', async () => {
+    locale = 'en';
+
+    const items = Array.from({ length: 35 }, (_, index) =>
+      mockConstituenta({
+        id: index + 1,
+        alias: `D${index + 1}`,
+        cst_class: CstClass.DERIVED,
+        cst_type: CstType.PREDICATE,
+        definition_formal: `D${index + 1} ≡ Pr1(α${index})`,
+        definition_resolved: 'Comment column text long enough to affect pagination in exported PDF.',
+        term_resolved: `term ${index + 1}`
+      })
+    );
+
+    const blob = await cstListToFile(items);
+    const pdfText = await pdfBlobToLatin1Text(blob);
+
+    assertNoInvalidPdfPageNumbers(pdfText);
+    expect(pdfText.length).toBeGreaterThan(0);
+  });
+});

--- a/rsconcept/frontend/src/features/rsform/utils/rsform2pdf.tsx
+++ b/rsconcept/frontend/src/features/rsform/utils/rsform2pdf.tsx
@@ -6,14 +6,20 @@ import { type AppLocale, DEFAULT_LOCALE, getMessageMapForLocale } from '@/i18n';
 import { type Constituenta, type RSForm } from '@rsconcept/domain/library';
 import { labelType } from '@rsconcept/domain/rslang/labels';
 
-import { urls } from '@/app';
+import { urls } from '@/app/urls';
 
 import { CDocument } from '@/components/pdf/CDocument';
 import { pdfs } from '@/components/pdf/pdf-styles';
 import { usePreferencesStore } from '@/stores/preferences';
 import { external_urls } from '@/utils/constants';
 
-import { addSpaces, addSpacesTypification, hyphenateCyrillic, protectShortRussianWords } from './pdf-utils';
+import {
+  addSpaces,
+  addSpacesTypification,
+  formatPdfPageRange,
+  hyphenateCyrillic,
+  protectShortRussianWords
+} from './pdf-utils';
 
 function handleIntlError(locale: AppLocale, error: unknown) {
   if (locale === 'en' && typeof error === 'object' && error && 'code' in error) {
@@ -69,7 +75,7 @@ function CstListDocument({ data }: { data: Constituenta[] }) {
       <Text
         fixed
         style={{ ...pdfs.footer, textAlign: 'center' }}
-        render={({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}`}
+        render={({ pageNumber, totalPages }) => formatPdfPageRange(pageNumber, totalPages)}
       />
     </CDocument>
   );
@@ -113,9 +119,13 @@ function SchemaFooter({ schema }: { schema: RSForm }) {
     <View fixed style={pdfs.footer}>
       <Text>{schema.alias}</Text>
       <Text
-        render={({ pageNumber, totalPages }) =>
-          intl.formatMessage({ id: 'tx.general.page.short' }) + ' ' + pageNumber + ' / ' + totalPages
-        }
+        render={({ pageNumber, totalPages }) => {
+          const range = formatPdfPageRange(pageNumber, totalPages);
+          if (!range) {
+            return '';
+          }
+          return intl.formatMessage({ id: 'tx.general.page.short' }) + ' ' + range;
+        }}
       />
     </View>
   );

--- a/rsconcept/frontend/src/features/rsform/utils/rsform2pdf.tsx
+++ b/rsconcept/frontend/src/features/rsform/utils/rsform2pdf.tsx
@@ -1,19 +1,25 @@
 import type { ReactNode } from 'react';
-import { IntlProvider, type IntlShape, useIntl } from 'react-intl';
+import { IntlProvider } from 'react-intl';
 import { Link, pdf, Text, View } from '@react-pdf/renderer';
 
-import { type AppLocale, DEFAULT_LOCALE, getMessageMapForLocale } from '@/i18n';
+import { type AppLocale, DEFAULT_LOCALE, getMessageMapForLocale, useTx } from '@/i18n';
 import { type Constituenta, type RSForm } from '@rsconcept/domain/library';
 import { labelType } from '@rsconcept/domain/rslang/labels';
 
-import { urls } from '@/app';
+import { urls } from '@/app/urls';
 
 import { CDocument } from '@/components/pdf/CDocument';
 import { pdfs } from '@/components/pdf/pdf-styles';
 import { usePreferencesStore } from '@/stores/preferences';
 import { external_urls } from '@/utils/constants';
 
-import { addSpaces, addSpacesTypification, hyphenateCyrillic, protectShortRussianWords } from './pdf-utils';
+import {
+  addSpaces,
+  addSpacesTypification,
+  formatPdfPageRange,
+  hyphenateCyrillic,
+  protectShortRussianWords
+} from './pdf-utils';
 
 function handleIntlError(locale: AppLocale, error: unknown) {
   if (locale === 'en' && typeof error === 'object' && error && 'code' in error) {
@@ -69,7 +75,7 @@ function CstListDocument({ data }: { data: Constituenta[] }) {
       <Text
         fixed
         style={{ ...pdfs.footer, textAlign: 'center' }}
-        render={({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}`}
+        render={({ pageNumber, totalPages }) => formatPdfPageRange(pageNumber, totalPages)}
       />
     </CDocument>
   );
@@ -87,18 +93,16 @@ function SchemaDocument({ data }: { data: RSForm }) {
 
 // ======== Internal components ========
 function SchemaTitle({ schema }: { schema: RSForm }) {
-  const intl = useIntl();
+  const tx = useTx();
   const url = `${external_urls.portal}${urls.schema(schema.id)}`;
   return (
     <View style={{ marginBottom: 10 }}>
       <Text style={{ fontSize: 16, fontWeight: 'bold', marginBottom: '3mm' }}>
-        {intl.formatMessage({ id: 'tx.schema' }) + ' ' + schema.title}
+        {tx('tx.schema') + ' ' + schema.title}
       </Text>
+      <Text style={{ fontSize: 12 }}>{tx('tx.lib.alias') + tx('tx.general.colon') + schema.alias}</Text>
       <Text style={{ fontSize: 12 }}>
-        {intl.formatMessage({ id: 'tx.lib.alias' }) + intl.formatMessage({ id: 'tx.general.colon' }) + schema.alias}
-      </Text>
-      <Text style={{ fontSize: 12 }}>
-        {intl.formatMessage({ id: 'tx.general.source' }) + intl.formatMessage({ id: 'tx.general.colon' })}
+        {tx('tx.general.source') + tx('tx.general.colon')}
         <Link src={url} style={{ textDecoration: 'underline' }}>
           {url}
         </Link>
@@ -108,32 +112,36 @@ function SchemaTitle({ schema }: { schema: RSForm }) {
 }
 
 function SchemaFooter({ schema }: { schema: RSForm }) {
-  const intl = useIntl();
+  const tx = useTx();
   return (
     <View fixed style={pdfs.footer}>
       <Text>{schema.alias}</Text>
       <Text
-        render={({ pageNumber, totalPages }) =>
-          intl.formatMessage({ id: 'tx.general.page.short' }) + ' ' + pageNumber + ' / ' + totalPages
-        }
+        render={({ pageNumber, totalPages }) => {
+          const range = formatPdfPageRange(pageNumber, totalPages);
+          if (!range) {
+            return '';
+          }
+          return tx('tx.general.page.short') + ' ' + range;
+        }}
       />
     </View>
   );
 }
 
 function CstTable({ data }: { data: Constituenta[] }) {
-  const intl = useIntl();
+  const tx = useTx();
   return (
     <>
       <View style={{ flex: 1 }}>
         {/* Table Header */}
         <View fixed style={pdfs.headerRow}>
           <Text style={{ ...pdfs.cell, width: '13mm' }}>ID</Text>
-          <Text style={{ ...pdfs.cell, width: '82mm' }}>{intl.formatMessage({ id: 'tx.lib.defineFormal' })}</Text>
-          <Text style={{ ...pdfs.cell, width: '38mm' }}>{intl.formatMessage({ id: 'tx.rslang.typification' })}</Text>
-          <Text style={{ ...pdfs.cell, width: '40mm' }}>{intl.formatMessage({ id: 'tx.lang.term' })}</Text>
+          <Text style={{ ...pdfs.cell, width: '82mm' }}>{tx('tx.lib.defineFormal')}</Text>
+          <Text style={{ ...pdfs.cell, width: '38mm' }}>{tx('tx.rslang.typification')}</Text>
+          <Text style={{ ...pdfs.cell, width: '40mm' }}>{tx('tx.lang.term')}</Text>
           <Text style={{ ...pdfs.cell, width: '82mm', borderRightWidth: 0 }}>
-            {`${intl.formatMessage({ id: 'tx.lib.defineText' })} / ${intl.formatMessage({ id: 'tx.lang.term' })}`}
+            {`${tx('tx.lib.defineText')} / ${tx('tx.lang.term')}`}
           </Text>
         </View>
 
@@ -153,7 +161,7 @@ function CstTable({ data }: { data: Constituenta[] }) {
               {protectShortRussianWords(cst.term_resolved)}
             </Text>
             <Text style={{ ...pdfs.cell, width: '82mm', borderRightWidth: 0 }} hyphenationCallback={hyphenateCyrillic}>
-              {protectShortRussianWords(getCommentColumnText(cst, intl.formatMessage))}
+              {protectShortRussianWords(getCommentColumnText(cst, tx))}
             </Text>
           </View>
         ))}
@@ -162,13 +170,13 @@ function CstTable({ data }: { data: Constituenta[] }) {
   );
 }
 
-function getCommentColumnText(cst: Constituenta, formatMessage: IntlShape['formatMessage']) {
+function getCommentColumnText(cst: Constituenta, tx: (id: string) => string) {
   let result = cst.definition_resolved;
   if (cst.convention) {
     if (result) {
       result += '\n';
     }
-    result += formatMessage({ id: 'tx.lib.convention' }) + ': ' + cst.convention;
+    result += tx('tx.lib.convention') + ': ' + cst.convention;
   }
   return result;
 }

--- a/rsconcept/rstool/docs/PORTAL-API.md
+++ b/rsconcept/rstool/docs/PORTAL-API.md
@@ -102,6 +102,26 @@ for (const item of portal.items) {
   а не alias `curl` (`Invoke-WebRequest`), если нужен CLI-синтаксис curl.
 - Сначала бери метаданные, если нужно только название или доступность схемы.
 
+### Windows: кодировка в скриптах пайплайна
+
+На Windows консоль по умолчанию часто **cp1251**; Python `print` падает с `UnicodeEncodeError`
+на символах вне этой таблицы (стрелки `→`, математика в логах и т.п.). Если `print` стоит
+**до** следующего шага пайплайна (например вызова `npx tsx`), скрипт оборвётся и артефакт
+не обновится.
+
+- **Запись JSON** — всегда UTF-8; для RSLang-символов в формулах не экранируй Unicode в JSON:
+
+```python
+path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding='utf-8')
+```
+
+- **Чтение** — `encoding='utf-8'`; для fetch API предпочитай `urllib` / `requests`, не
+  `Out-File` без явной UTF-8 в PowerShell.
+- **Логи в `print`** — ASCII (`->`, `...`) или только id/alias без математики; не полагайся
+  на то, что консоль UTF-8.
+- При необходимости Unicode в stdout: `PYTHONIOENCODING=utf-8` или `sys.stdout.reconfigure(encoding='utf-8')`
+  (Python 3.7+), но для агентских скриптов проще держать вывод в ASCII.
+
 ## Не делай
 
 - Не парси HTML SPA.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * PDF documents no longer embed invalid page numbers in footers during generation. Page ranges are now properly validated before rendering.

* **Tests**
  * Added comprehensive test coverage for PDF footer generation to ensure valid page numbering.

* **Documentation**
  * Added guidance for handling text encoding on Windows during pipeline operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->